### PR TITLE
feat(ui): Redesenha a página de treinamento com layout de cards

### DIFF
--- a/client/src/components/TrainingHistory.tsx
+++ b/client/src/components/TrainingHistory.tsx
@@ -5,7 +5,8 @@ import { FileUpload } from './FileUpload';
 import { ModelMetrics } from './ModelMetrics';
 import { TrainingDataViewer } from './TrainingDataViewer';
 import { ModelComparison } from './ModelComparison';
-import { Play, Calendar, CheckCircle, XCircle, Clock, ChevronDown, ChevronUp, Trash2 } from 'lucide-react';
+import { Play, Calendar, CheckCircle, XCircle, Clock, ChevronDown, ChevronUp, Trash2, BrainCircuit, History } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 export const TrainingHistory: React.FC = () => {
   const [trainingHistory, setTrainingHistory] = useState<TrainingHistoryEntry[]>([]);
@@ -37,7 +38,7 @@ export const TrainingHistory: React.FC = () => {
         setTrainingHistory(history);
         setOptimizationLogs(logs);
       } catch (err) {
-        setError('Erro ao carregar histórico');
+        setError('Erro ao carregar dados da página.');
       } finally {
         setLoading(false);
       }
@@ -64,7 +65,7 @@ export const TrainingHistory: React.FC = () => {
         setTrainingError(result.message);
       }
     } catch (err) {
-      setTrainingError('Erro ao treinar modelo');
+      setTrainingError('Ocorreu um erro inesperado ao treinar o modelo.');
     } finally {
       setTrainingLoading(false);
     }
@@ -81,22 +82,12 @@ export const TrainingHistory: React.FC = () => {
     }
   };
 
-  const handleDeleteTraining = async (trainingId: string) => {
-    setDeleteModal({ 
-      show: true, 
-      type: 'training', 
-      id: trainingId,
-      title: 'Excluir Treinamento'
-    });
+  const handleDeleteTraining = (trainingId: string) => {
+    setDeleteModal({ show: true, type: 'training', id: trainingId, title: 'Excluir Treinamento' });
   };
 
-  const handleDeleteOptimization = async (optimizationId: string) => {
-    setDeleteModal({ 
-      show: true, 
-      type: 'optimization', 
-      id: optimizationId,
-      title: 'Excluir Otimização'
-    });
+  const handleDeleteOptimization = (optimizationId: string) => {
+    setDeleteModal({ show: true, type: 'optimization', id: optimizationId, title: 'Excluir Otimização' });
   };
 
   const confirmDelete = async () => {
@@ -104,20 +95,17 @@ export const TrainingHistory: React.FC = () => {
     try {
       if (deleteModal.type === 'training') {
         await realApiService.deleteTraining(deleteModal.id);
-        // Refresh training history
         const history = await realApiService.getTrainingHistory();
         setTrainingHistory(history);
       } else {
         await realApiService.deleteOptimization(deleteModal.id);
-        // Refresh optimization logs
         const logs = await realApiService.getOptimizationLogs();
         setOptimizationLogs(logs);
       }
-      
       setError(null);
       setDeleteModal({ show: false, type: 'training', id: '', title: '' });
     } catch (err) {
-      setError(`Erro ao excluir ${deleteModal.type === 'training' ? 'treinamento' : 'otimização'}: ` + (err as Error).message);
+      setError(`Erro ao excluir ${deleteModal.type === 'training' ? 'treinamento' : 'otimização'}: ${(err as Error).message}`);
     } finally {
       setDeletingId(null);
     }
@@ -127,194 +115,123 @@ export const TrainingHistory: React.FC = () => {
     setDeleteModal({ show: false, type: 'training', id: '', title: '' });
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString('pt-BR');
-  };
+  const formatDate = (dateString: string) => new Date(dateString).toLocaleString('pt-BR');
 
   const formatDuration = (start: string, end: string) => {
-    const startDate = new Date(start);
-    const endDate = new Date(end);
-    const diffMs = endDate.getTime() - startDate.getTime();
+    const diffMs = new Date(end).getTime() - new Date(start).getTime();
     const diffMins = Math.floor(diffMs / 60000);
     const diffSecs = Math.floor((diffMs % 60000) / 1000);
-    
-    if (diffMins > 0) {
-      return `${diffMins} min ${diffSecs} seg`;
-    }
-    return `${diffSecs} segundos`;
+    return diffMins > 0 ? `${diffMins} min ${diffSecs} seg` : `${diffSecs} segundos`;
   };
 
   return (
-    <div className="max-w-6xl mx-auto">
-      <div className="bg-white rounded-lg shadow-lg p-6">
-        <h1 className="text-2xl font-bold text-gray-900 mb-6">Histórico de Treinamento</h1>
-
-        {/* Model Metrics */}
-        <ModelMetrics />
-
-        {/* Training Section */}
-        <div className="mb-10">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Treinar Novo Modelo</h2>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center">
+              <BrainCircuit className="h-6 w-6 mr-2" />
+              Treinar Novo Modelo
+            </CardTitle>
+            <CardDescription>
+              Faça o upload de um arquivo (.xlsx, .xls, .csv) com dados históricos para treinar e atualizar o modelo de otimização.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
             <FileUpload
               onFileSelect={setTrainingFile}
               accept=".xlsx,.xls,.csv"
               loading={trainingLoading}
               error={trainingError || undefined}
               success={trainingSuccess}
-              label="Upload de Dados de Treinamento"
-              description="Arquivo Excel ou CSV com dados históricos de produção"
+              label="Arquivo de Dados"
+              description="Selecione ou arraste o arquivo de treinamento."
             />
-            
-            <div className="flex flex-col justify-end">
-              <button
-                onClick={handleTrainModel}
-                disabled={trainingLoading || !trainingFile}
-                className="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
-              >
-                <Play className="h-5 w-5" />
-                <span>{trainingLoading ? 'Treinando...' : 'Treinar Modelo'}</span>
-              </button>
-              
-              {trainingSuccess && (
-                <p className="mt-2 text-sm text-green-600">
-                  Modelo treinado com sucesso!
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Model Comparison Toggle */}
-        <div className="mb-6">
-          <button
-            onClick={() => setShowModelComparison(!showModelComparison)}
-            className="flex items-center text-blue-600 hover:text-blue-800"
-          >
-            {showModelComparison ? (
-              <>
-                <ChevronUp className="h-5 w-5 mr-1" />
-                Ocultar Comparação de Modelos
-              </>
-            ) : (
-              <>
-                <ChevronDown className="h-5 w-5 mr-1" />
-                Comparar Modelos
-              </>
+            <button
+              onClick={handleTrainModel}
+              disabled={trainingLoading || !trainingFile}
+              className="w-full bg-primary text-primary-foreground px-4 py-2 rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
+            >
+              <Play className="h-5 w-5" />
+              <span>{trainingLoading ? 'Treinando...' : 'Iniciar Treinamento'}</span>
+            </button>
+            {trainingSuccess && (
+              <p className="mt-2 text-sm text-green-600 flex items-center justify-center">
+                <CheckCircle className="h-4 w-4 mr-1" />
+                Modelo treinado com sucesso!
+              </p>
             )}
-          </button>
-        </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Métricas do Modelo</CardTitle>
+            <CardDescription>
+              Visão geral do desempenho do modelo atual.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ModelMetrics />
+          </CardContent>
+        </Card>
+      </div>
 
-        {/* Model Comparison */}
-        {showModelComparison && (
-          <div className="mb-10">
-            <ModelComparison />
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <History className="h-6 w-6 mr-2" />
+            Histórico e Análise de Treinamentos
+          </CardTitle>
+          <CardDescription>
+            Revise os treinamentos passados e compare o desempenho dos modelos.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex space-x-4">
+            <button
+              onClick={() => setShowModelComparison(!showModelComparison)}
+              className="flex items-center text-sm font-medium text-primary hover:text-primary/90"
+            >
+              {showModelComparison ? <ChevronUp className="h-4 w-4 mr-1" /> : <ChevronDown className="h-4 w-4 mr-1" />}
+              Comparar Modelos
+            </button>
+            <button
+              onClick={() => setShowTrainingData(!showTrainingData)}
+              className="flex items-center text-sm font-medium text-primary hover:text-primary/90"
+            >
+              {showTrainingData ? <ChevronUp className="h-4 w-4 mr-1" /> : <ChevronDown className="h-4 w-4 mr-1" />}
+              Visualizar Dados de Treinamento
+            </button>
           </div>
-        )}
 
-        {/* Training Data Viewer Toggle */}
-        <div className="mb-6">
-          <button
-            onClick={() => setShowTrainingData(!showTrainingData)}
-            className="flex items-center text-blue-600 hover:text-blue-800"
-          >
-            {showTrainingData ? (
-              <>
-                <ChevronUp className="h-5 w-5 mr-1" />
-                Ocultar Dados de Treinamento
-              </>
-            ) : (
-              <>
-                <ChevronDown className="h-5 w-5 mr-1" />
-                Visualizar Dados de Treinamento
-              </>
-            )}
-          </button>
-        </div>
-
-        {/* Training Data Viewer */}
-        {showTrainingData && (
-          <div className="mb-10">
-            <TrainingDataViewer />
-          </div>
-        )}
-
-        {/* Training History */}
-        <div className="mb-10">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Histórico de Treinamentos</h2>
+          {showModelComparison && <ModelComparison />}
+          {showTrainingData && <TrainingDataViewer />}
           
           {loading ? (
-            <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-            </div>
+            <div className="flex justify-center py-8"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div></div>
           ) : error ? (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p className="text-sm text-red-800">{error}</p>
-            </div>
+            <div className="text-destructive text-center py-8">{error}</div>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto border rounded-lg">
+              <table className="min-w-full divide-y divide-border">
+                <thead className="bg-muted/50">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Data/Hora
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Duração
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Exemplos Processados
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Detalhes
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Ações
-                    </th>
+                    {['Data/Hora', 'Status', 'Duração', 'Exemplos', 'Detalhes', 'Ações'].map(header => (
+                      <th key={header} className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">{header}</th>
+                    ))}
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="bg-card divide-y divide-border">
                   {trainingHistory.map((entry) => (
-                    <tr key={entry.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <div className="flex items-center">
-                          <Calendar className="h-4 w-4 mr-2 text-gray-400" />
-                          {formatDate(entry.data_inicio)}
-                        </div>
-                      </td>
+                    <tr key={entry.id} className="hover:bg-muted/50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm"><div className="flex items-center"><Calendar className="h-4 w-4 mr-2 text-muted-foreground" />{formatDate(entry.data_inicio)}</div></td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm"><div className="flex items-center">{getStatusIcon(entry.status)}<span className="ml-2">{entry.status}</span></div></td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">{entry.data_fim ? formatDuration(entry.data_inicio, entry.data_fim) : '-'}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">{entry.exemplos_processados}</td>
+                      <td className="px-6 py-4 text-sm text-destructive">{entry.mensagem_erro}</td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <div className="flex items-center">
-                          {getStatusIcon(entry.status)}
-                          <span className="ml-2">{entry.status}</span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {entry.data_fim ? formatDuration(entry.data_inicio, entry.data_fim) : '-'}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {entry.exemplos_processados}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500">
-                        {entry.mensagem_erro && (
-                          <span className="text-red-600">{entry.mensagem_erro}</span>
-                        )}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <button
-                          onClick={() => handleDeleteTraining(entry.id)}
-                          disabled={deletingId === entry.id}
-                          className="text-red-600 hover:text-red-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
-                          title="Excluir treinamento"
-                        >
-                          {deletingId === entry.id ? (
-                            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-red-600"></div>
-                          ) : (
-                            <Trash2 className="h-4 w-4" />
-                          )}
+                        <button onClick={() => handleDeleteTraining(entry.id)} disabled={deletingId === entry.id} className="text-destructive hover:text-destructive/80 disabled:opacity-50" title="Excluir treinamento">
+                          {deletingId === entry.id ? <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-destructive"></div> : <Trash2 className="h-4 w-4" />}
                         </button>
                       </td>
                     </tr>
@@ -323,78 +240,43 @@ export const TrainingHistory: React.FC = () => {
               </table>
             </div>
           )}
-        </div>
+        </CardContent>
+      </Card>
 
-        {/* Optimization Logs */}
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Logs de Otimização</h2>
-          
+      <Card>
+        <CardHeader>
+          <CardTitle>Logs de Otimização</CardTitle>
+          <CardDescription>Logs de execuções de otimizações de produção.</CardDescription>
+        </CardHeader>
+        <CardContent>
           {loading ? (
-            <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-            </div>
+            <div className="flex justify-center py-8"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div></div>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto border rounded-lg">
+              <table className="min-w-full divide-y divide-border">
+                <thead className="bg-muted/50">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Data/Hora
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Tolerância
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Linhas Processadas
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Resumo
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Ações
-                    </th>
+                    {['Data/Hora', 'Tolerância', 'Linhas', 'Resumo', 'Ações'].map(header => (
+                      <th key={header} className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">{header}</th>
+                    ))}
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody className="bg-card divide-y divide-border">
                   {optimizationLogs.map((log) => (
-                    <tr key={log.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <div className="flex items-center">
-                          <Calendar className="h-4 w-4 mr-2 text-gray-400" />
-                          {formatDate(log.data_hora)}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {log.tolerancia}%
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {log.linhas_processadas}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500">
+                    <tr key={log.id} className="hover:bg-muted/50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm"><div className="flex items-center"><Calendar className="h-4 w-4 mr-2 text-muted-foreground" />{formatDate(log.data_hora)}</div></td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">{log.tolerancia}%</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm">{log.linhas_processadas}</td>
+                      <td className="px-6 py-4 text-sm">
                         <div className="flex space-x-4">
-                          <span className="text-green-600">
-                            ↑ {log.resumo.aumentos}
-                          </span>
-                          <span className="text-red-600">
-                            ↓ {log.resumo.diminuicoes}
-                          </span>
-                          <span className="text-gray-600">
-                            = {log.resumo.inalterados}
-                          </span>
+                          <span className="text-green-600">↑ {log.resumo.aumentos}</span>
+                          <span className="text-red-600">↓ {log.resumo.diminuicoes}</span>
+                          <span>= {log.resumo.inalterados}</span>
                         </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <button
-                          onClick={() => handleDeleteOptimization(log.id)}
-                          disabled={deletingId === log.id}
-                          className="text-red-600 hover:text-red-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
-                          title="Excluir otimização"
-                        >
-                          {deletingId === log.id ? (
-                            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-red-600"></div>
-                          ) : (
-                            <Trash2 className="h-4 w-4" />
-                          )}
+                        <button onClick={() => handleDeleteOptimization(log.id)} disabled={deletingId === log.id} className="text-destructive hover:text-destructive/80 disabled:opacity-50" title="Excluir otimização">
+                          {deletingId === log.id ? <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-destructive"></div> : <Trash2 className="h-4 w-4" />}
                         </button>
                       </td>
                     </tr>
@@ -403,58 +285,34 @@ export const TrainingHistory: React.FC = () => {
               </table>
             </div>
           )}
-        </div>
+        </CardContent>
+      </Card>
 
-        {/* Modal de Confirmação de Exclusão */}
-        {deleteModal.show && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
-              <div className="p-6">
-                <div className="flex items-center mb-4">
-                  <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
-                    <Trash2 className="h-6 w-6 text-red-600" />
-                  </div>
-                </div>
-                
-                <div className="text-center">
-                  <h3 className="text-lg leading-6 font-medium text-gray-900 mb-2">
-                    {deleteModal.title}
-                  </h3>
-                  <div className="mt-2">
-                    <p className="text-sm text-gray-500">
-                      Tem certeza que deseja excluir {deleteModal.type === 'training' ? 'este treinamento' : 'esta otimização'}? 
-                      Esta ação não pode ser desfeita.
-                    </p>
-                  </div>
-                </div>
-                
-                <div className="mt-6 flex space-x-4">
-                  <button
-                    onClick={cancelDelete}
-                    className="flex-1 bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                  >
-                    Cancelar
-                  </button>
-                  <button
-                    onClick={confirmDelete}
-                    disabled={deletingId === deleteModal.id}
-                    className="flex-1 bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
-                  >
-                    {deletingId === deleteModal.id ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Excluindo...
-                      </>
-                    ) : (
-                      'Excluir'
-                    )}
-                  </button>
-                </div>
+      {deleteModal.show && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg shadow-xl max-w-md w-full mx-4 border">
+            <div className="p-6 text-center">
+              <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-destructive/10">
+                <Trash2 className="h-6 w-6 text-destructive" />
+              </div>
+              <h3 className="text-lg leading-6 font-medium mt-4">{deleteModal.title}</h3>
+              <div className="mt-2">
+                <p className="text-sm text-muted-foreground">
+                  Tem certeza que deseja excluir? Esta ação não pode ser desfeita.
+                </p>
+              </div>
+              <div className="mt-6 flex space-x-4">
+                <button onClick={cancelDelete} className="flex-1 bg-transparent py-2 px-4 border rounded-md shadow-sm text-sm font-medium hover:bg-accent focus:outline-none">
+                  Cancelar
+                </button>
+                <button onClick={confirmDelete} disabled={deletingId === deleteModal.id} className="flex-1 bg-destructive text-destructive-foreground py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium hover:bg-destructive/90 disabled:opacity-50 flex items-center justify-center">
+                  {deletingId === deleteModal.id ? <><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>Excluindo...</> : 'Excluir'}
+                </button>
               </div>
             </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,0 +1,73 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
Esta alteração redesenha completamente a página de Treinamento (`/training`) para fornecer uma experiência de usuário mais moderna e elegante, conforme solicitado.

As principais mudanças incluem:
- Introdução de um componente `Card` reutilizável em `client/src/components/ui/card.tsx`, seguindo as convenções do Shadcn/UI.
- Criação do arquivo de utilitários `client/src/lib/utils.ts` para a função `cn`, necessária para o novo componente.
- Refatoração completa do componente `TrainingHistory.tsx` para usar o novo layout baseado em cards, organizando as seções de treinamento, métricas, histórico e logs em blocos visuais distintos e mais claros.
- Melhoria da hierarquia visual, espaçamento e uso de cores temáticas para uma aparência mais polida.