### PR TITLE
fix(ui): Refatora o componente de métricas para corrigir o layout

### DIFF
--- a/client/src/components/ModelMetrics.tsx
+++ b/client/src/components/ModelMetrics.tsx
@@ -2,11 +2,23 @@ import React, { useState, useEffect } from 'react';
 import { realApiService } from '../services/realApiService';
 import { BarChart, TrendingUp, Database, Clock } from 'lucide-react';
 
+// Define a reusable Metric Item component
+const MetricItem = ({ icon, label, value }: { icon: React.ReactNode, label: string, value: string | number }) => (
+  <div className="flex items-center space-x-4">
+    <div className="p-3 rounded-full bg-muted text-muted-foreground">
+      {icon}
+    </div>
+    <div>
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <p className="text-2xl font-semibold">{value}</p>
+    </div>
+  </div>
+);
+
 export const ModelMetrics: React.FC = () => {
   const [metrics, setMetrics] = useState({
     totalTrainings: 0,
     lastTraining: '',
-    activeModel: '',
     accuracy: 0,
     totalOptimizations: 0
   });
@@ -15,27 +27,16 @@ export const ModelMetrics: React.FC = () => {
   useEffect(() => {
     const fetchMetrics = async () => {
       try {
-        // Obter dados do usuário
         const { data: { user } } = await realApiService.getCurrentUser();
         if (!user) return;
 
-        // Obter estatísticas de treinamento
         const trainingHistory = await realApiService.getTrainingHistory();
         const optimizationLogs = await realApiService.getOptimizationLogs();
         
-        // Obter modelo ativo
-        const { data: modelData } = await realApiService.supabase
-          .from('model_weights')
-          .select('version, created_at')
-          .eq('user_id', user.id)
-          .eq('is_active', true)
-          .single();
-        
         setMetrics({
           totalTrainings: trainingHistory.length,
-          lastTraining: trainingHistory[0]?.data_inicio || 'Nenhum treinamento',
-          activeModel: modelData?.version || 'Nenhum modelo ativo',
-          accuracy: 85, // Valor simulado - em implementação real, calcular com base em dados reais
+          lastTraining: trainingHistory[0]?.data_inicio || 'N/A',
+          accuracy: 85, // Simulated value
           totalOptimizations: optimizationLogs.length
         });
       } catch (error) {
@@ -49,78 +50,48 @@ export const ModelMetrics: React.FC = () => {
   }, []);
 
   const formatDate = (dateString: string) => {
+    if (dateString === 'N/A') return 'N/A';
     return new Date(dateString).toLocaleDateString('pt-BR');
   };
 
   if (loading) {
     return (
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="animate-pulse flex space-x-4">
-          <div className="flex-1 space-y-4 py-1">
-            <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-            <div className="space-y-2">
-              <div className="h-4 bg-gray-200 rounded"></div>
-              <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+      <div className="space-y-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="animate-pulse flex items-center space-x-4">
+            <div className="h-12 w-12 rounded-full bg-muted"></div>
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-muted rounded w-3/4"></div>
+              <div className="h-6 bg-muted rounded w-1/2"></div>
             </div>
           </div>
-        </div>
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex items-center">
-          <div className="p-3 rounded-full bg-blue-100 text-blue-600">
-            <Database className="h-6 w-6" />
-          </div>
-          <div className="ml-4">
-            <p className="text-sm font-medium text-gray-600">Total de Treinamentos</p>
-            <p className="text-2xl font-semibold text-gray-900">{metrics.totalTrainings}</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex items-center">
-          <div className="p-3 rounded-full bg-green-100 text-green-600">
-            <TrendingUp className="h-6 w-6" />
-          </div>
-          <div className="ml-4">
-            <p className="text-sm font-medium text-gray-600">Precisão do Modelo</p>
-            <p className="text-2xl font-semibold text-gray-900">{metrics.accuracy}%</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex items-center">
-          <div className="p-3 rounded-full bg-purple-100 text-purple-600">
-            <BarChart className="h-6 w-6" />
-          </div>
-          <div className="ml-4">
-            <p className="text-sm font-medium text-gray-600">Otimizações Realizadas</p>
-            <p className="text-2xl font-semibold text-gray-900">{metrics.totalOptimizations}</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex items-center">
-          <div className="p-3 rounded-full bg-yellow-100 text-yellow-600">
-            <Clock className="h-6 w-6" />
-          </div>
-          <div className="ml-4">
-            <p className="text-sm font-medium text-gray-600">Último Treinamento</p>
-            <p className="text-lg font-semibold text-gray-900">
-              {metrics.lastTraining !== 'Nenhum treinamento' 
-                ? formatDate(metrics.lastTraining) 
-                : 'Nenhum treinamento'}
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-8 gap-x-4">
+      <MetricItem
+        icon={<Database className="h-6 w-6" />}
+        label="Total de Treinamentos"
+        value={metrics.totalTrainings}
+      />
+      <MetricItem
+        icon={<TrendingUp className="h-6 w-6" />}
+        label="Precisão (Simulada)"
+        value={`${metrics.accuracy}%`}
+      />
+      <MetricItem
+        icon={<BarChart className="h-6 w-6" />}
+        label="Otimizações Realizadas"
+        value={metrics.totalOptimizations}
+      />
+      <MetricItem
+        icon={<Clock className="h-6 w-6" />}
+        label="Último Treinamento"
+        value={formatDate(metrics.lastTraining)}
+      />
     </div>
   );
 };

--- a/server.log
+++ b/server.log
@@ -2,3 +2,4 @@
 > rest-express@1.0.0 dev
 > NODE_ENV=development npx tsx server/index.ts
 
+10:44:59 PM [express] serving on port 5000


### PR DESCRIPTION
O componente `ModelMetrics` possuía seu próprio layout de grade interna e estilos de caixa, o que causava distorção visual quando colocado dentro de um componente `Card` no redesenho da página de Treinamento.

Esta alteração refatora o `ModelMetrics.tsx` para:
- Remover seu layout de grade e estilos de caixa próprios.
- Renderizar os itens de métrica individuais de forma simples.
- Delegar a responsabilidade do layout ao componente pai (`TrainingHistory.tsx`).

Isso corrige o problema do "quadro de métricas distorcido" e garante que o componente seja exibido corretamente dentro do novo design de cards.