### PR TITLE
fix(optimizer): Adiciona limite de linhas para evitar crash de perfor…

### DIFF
--- a/client/src/components/ProductionOptimizer.tsx
+++ b/client/src/components/ProductionOptimizer.tsx
@@ -60,6 +60,9 @@ export const ProductionOptimizer: React.FC = () => {
           });
         }
         if (productionItems.length === 0) throw new Error("Nenhum item válido encontrado na planilha.");
+        if (productionItems.length > 5000) {
+          throw new Error("O arquivo é muito grande para ser processado no navegador. Por favor, use um arquivo com menos de 5000 linhas.");
+        }
         setFile(selectedFile);
         setItems(productionItems);
         setStep('configure');


### PR DESCRIPTION
…mance

Resolve o problema de crash (tela preta) que ocorria ao otimizar arquivos grandes. A causa raiz foi identificada como uso excessivo de memória/CPU devido a uma lógica de otimização complexa sendo executada no cliente.

Esta correção introduz uma salvaguarda pragmática:
- **Limite de Linhas:** Um limite de 5000 linhas foi adicionado ao processo de upload de arquivos. Se um arquivo exceder este limite, o usuário receberá uma mensagem de erro clara em vez de o navegador travar.

Isso previne o crash e melhora a estabilidade da aplicação para arquivos grandes, embora uma solução de longo prazo deva mover a lógica de otimização para o servidor.